### PR TITLE
feat: add admin mode with teacher login/logout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+bcrypt

--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
+import secrets
+import bcrypt
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +22,22 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from JSON file
+teachers_file = Path(__file__).parent / "teachers.json"
+with open(teachers_file) as f:
+    teachers_data = json.load(f)
+teachers = {t["username"]: t["password_hash"] for t in teachers_data["teachers"]}
+
+# In-memory session tokens for authenticated teachers
+active_tokens: set[str] = set()
+
+security = HTTPBearer(auto_error=False)
+
+
+def require_teacher(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials is None or credentials.credentials not in active_tokens:
+        raise HTTPException(status_code=401, detail="Authentication required")
 
 # In-memory activity database
 activities = {
@@ -83,13 +103,32 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.post("/login")
+def login(username: str, password: str):
+    """Authenticate a teacher and return a session token"""
+    password_hash = teachers.get(username)
+    if not password_hash or not bcrypt.checkpw(password.encode(), password_hash.encode()):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    token = secrets.token_hex(32)
+    active_tokens.add(token)
+    return {"token": token}
+
+
+@app.post("/logout")
+def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Invalidate the current session token"""
+    if credentials and credentials.credentials in active_tokens:
+        active_tokens.discard(credentials.credentials)
+    return {"message": "Logged out successfully"}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, _: None = Depends(require_teacher)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +150,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, _: None = Depends(require_teacher)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,87 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Auth state
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginError = document.getElementById("login-error");
+  const loggedInInfo = document.getElementById("logged-in-info");
+  const signupContainer = document.getElementById("signup-container");
+
+  function getToken() {
+    return sessionStorage.getItem("authToken");
+  }
+
+  function isLoggedIn() {
+    return !!getToken();
+  }
+
+  function updateAuthUI() {
+    if (isLoggedIn()) {
+      loginBtn.classList.add("hidden");
+      loggedInInfo.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+    } else {
+      loginBtn.classList.remove("hidden");
+      loggedInInfo.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+    }
+    fetchActivities();
+  }
+
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    document.getElementById("login-username").focus();
+  });
+
+  document.getElementById("cancel-login-btn").addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+    loginError.classList.add("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("login-username").value;
+    const password = document.getElementById("login-password").value;
+
+    try {
+      const response = await fetch(
+        `/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      const result = await response.json();
+
+      if (response.ok) {
+        sessionStorage.setItem("authToken", result.token);
+        loginModal.classList.add("hidden");
+        loginForm.reset();
+        loginError.classList.add("hidden");
+        updateAuthUI();
+      } else {
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginError.textContent = "Login failed. Please try again.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    const token = getToken();
+    if (token) {
+      await fetch("/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      sessionStorage.removeItem("authToken");
+    }
+    updateAuthUI();
+  });
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -30,7 +111,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${isLoggedIn() ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
@@ -80,6 +161,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: { Authorization: `Bearer ${getToken()}` },
         }
       );
 
@@ -124,6 +206,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: `Bearer ${getToken()}` },
         }
       );
 
@@ -156,5 +239,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  updateAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,36 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-controls">
+        <button id="login-btn" title="Teacher Login">👤 Login</button>
+        <span id="logged-in-info" class="hidden">
+          <span id="logged-in-user">Teacher</span>
+          <button id="logout-btn">Logout</button>
+        </span>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-username">Username:</label>
+            <input type="text" id="login-username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" required autocomplete="current-password" />
+          </div>
+          <div id="login-error" class="error hidden"></div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="cancel-login-btn">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -198,3 +198,75 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+/* Auth controls in header */
+header {
+  position: relative;
+}
+
+#auth-controls {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#auth-controls button {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
+#auth-controls button:hover {
+  background-color: rgba(255, 255, 255, 0.35);
+}
+
+#logged-in-user {
+  color: white;
+  font-size: 14px;
+}
+
+/* Login modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+.modal-actions button[type="button"] {
+  background-color: #aaa;
+}
+
+.modal-actions button[type="button"]:hover {
+  background-color: #888;
+}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher",
+      "password_hash": "$2b$12$g6HXNe8EA.BtR2hHXhpkNePLXMqxjrD2d4leI769ojQLMOb.rtlXm"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves #5 — students were removing each other from activities to free up spots. This PR adds teacher-only authentication so only logged-in teachers can register or unregister students.

## Changes

### Backend (`src/app.py`)
- Load teacher credentials from `src/teachers.json` (bcrypt-hashed passwords)
- In-memory session token store using `secrets.token_hex(32)`
- `POST /login` — verifies credentials, returns a session token
- `POST /logout` — invalidates the token
- `POST /activities/{name}/signup` — now requires a valid Bearer token
- `DELETE /activities/{name}/unregister` — now requires a valid Bearer token
- `GET /activities` — unchanged, still public for all students

### Frontend (`src/static/`)
- **index.html**: login button (👤) in the header top-right; login modal with username/password fields
- **app.js**: login/logout flow storing token in `sessionStorage`; sign-up form and ❌ unregister buttons hidden unless teacher is logged in; all mutating requests send `Authorization: Bearer <token>`
- **styles.css**: modal overlay + content styles; auth controls positioning in header

### Credentials (`src/teachers.json`)
- Default teacher: username `teacher`, password `mergington123` (bcrypt-hashed)

## Testing
1. Load the page — sign-up form and unregister buttons are hidden
2. Click 👤 Login → enter `teacher` / `mergington123` → form and unregister buttons appear
3. Logout → form and buttons hidden again
4. Attempting signup/unregister without a token returns HTTP 401